### PR TITLE
Added readonly as mount option flag

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -362,7 +362,7 @@ class FUSE(object):
             args.append('-d')
         if kwargs.pop('nothreads', False):
             args.append('-s')
-        if kwards.pop('readonly', False):
+        if kwargs.pop('readonly', False):
 	    args.append('-r')
         kwargs.setdefault('fsname', operations.__class__.__name__)
         args.append('-o')


### PR DESCRIPTION
could this small change to the fuse.py be merge into the main project.  We are using fuse.py in cadcVOFS and would like to have readonly mounting as an option.  Be sure to get the commit where I correct the kward typos... bad commit 
