### PR TITLE
Fix setuptools install_requires errors

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README*
+include README.rst

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.rst

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     fixers = set()
 
-with open('README') as readme:
+with open('README.rst') as readme:
     documentation = readme.read()
 
 setup(


### PR DESCRIPTION
I've recently created a project that uses your fusepy library.  For some reason, when I specify fusepy 2.0.1 as a dependency by including it in the `install_requires` list in setup.py, `python setup.py install` for my project fails with the following error message:

```
error: README: No such file or directory
```

When I use a version of your project with the patch included in this pull request, it works fine.  If possible, can you merge in this patch and update the pypi version of fusepy with it?  If you know of another way to fix my issue, please let me know.  Thanks!
