### PR TITLE
Remove create_string_buffer from read()

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -588,8 +588,7 @@ class FUSE(object):
         assert retsize <= size, \
             'actual amount read %d greater than expected %d' % (retsize, size)
 
-        data = create_string_buffer(ret, retsize)
-        memmove(buf, data, retsize)
+        memmove(buf, ret, retsize)
         return retsize
 
     def write(self, path, buf, size, offset, fip):


### PR DESCRIPTION
It was in fact never used in any released version since 2.0. Here a short history:

17.08.2009 Added in 768bfe0621a48f238bcb65093c37917e0e7fefef

15.07.2012 Not used 3c639594cb3489d8eedae6ac9c2ecdcbe1da9da6

27.07.2012 v2.0 and v2.0.1 are released
02.03.2013 v2.0.2 gets released

11.10.2013 used again with 551aea355dd6c36ca18ce24af8fc2fa37fd3f77d

05.04.2016 v2.0.3 and v2.0.4 get released
