### PR TITLE
allow overriding libfuse path using envvar LIBFUSE_PATH

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -18,7 +18,7 @@ from __future__ import print_function, absolute_import, division
 from ctypes import *
 from ctypes.util import find_library
 from errno import *
-from os import strerror
+from os import environ, strerror
 from platform import machine, system
 from signal import signal, SIGINT, SIG_DFL
 from stat import S_IFDIR
@@ -64,6 +64,8 @@ if _system == 'Darwin':
                      find_library('fuse'))
 else:
     _libfuse_path = find_library('fuse')
+
+_libfuse_path = environ('LIBFUSE_PATH', _libfuse_path)
 
 if not _libfuse_path:
     raise EnvironmentError('Unable to find libfuse')


### PR DESCRIPTION
This allows users to manually override the libfuse path determined by `find_library`.

See https://github.com/terencehonles/fusepy/issues/35#issuecomment-147133806.
