### PR TITLE
Fix typos

### DIFF
--- a/examples/memoryll.py
+++ b/examples/memoryll.py
@@ -44,7 +44,7 @@ class Memory(FUSELL):
         attr = self.attr[ino]
 
         if attr:
-            entry = {'ino': ino, 'attr': attr, 'atttr_timeout': 1.0, 'entry_timeout': 1.0}
+            entry = {'ino': ino, 'attr': attr, 'attr_timeout': 1.0, 'entry_timeout': 1.0}
             self.reply_entry(req, entry)
         else:
             self.reply_err(req, ENOENT)
@@ -69,7 +69,7 @@ class Memory(FUSELL):
         self.parent[ino] = parent
         self.children[parent][name] = ino
 
-        entry = {'ino': ino, 'attr': attr, 'atttr_timeout': 1.0, 'entry_timeout': 1.0}
+        entry = {'ino': ino, 'attr': attr, 'attr_timeout': 1.0, 'entry_timeout': 1.0}
         self.reply_entry(req, entry)
 
     def mknod(self, req, parent, name, mode, rdev):
@@ -92,7 +92,7 @@ class Memory(FUSELL):
         self.attr[parent]['st_nlink'] += 1
         self.children[parent][name] = ino
 
-        entry = {'ino': ino, 'attr': attr, 'atttr_timeout': 1.0, 'entry_timeout': 1.0}
+        entry = {'ino': ino, 'attr': attr, 'attr_timeout': 1.0, 'entry_timeout': 1.0}
         self.reply_entry(req, entry)
 
     def open(self, req, ino, fi):

--- a/fuse.py
+++ b/fuse.py
@@ -842,7 +842,7 @@ class Operations(object):
 
         st_atime, st_mtime and st_ctime should be floats.
 
-        NOTE: There is an incombatibility between Linux and Mac OS X
+        NOTE: There is an incompatibility between Linux and Mac OS X
         concerning st_nlink of directories. Mac OS X counts all files inside
         the directory, while Linux counts only the subdirectories.
         '''


### PR DESCRIPTION
These misspellings were found using [mwic](http://jwilk.net/software/mwic).
