### PR TITLE
Nanosecond opt-in, revision 2

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -455,7 +455,7 @@ class FUSE(object):
 
         requested_features = getattr(operations, 'requested_features', {})
         for feature_name in __features__.keys():
-            setattr(self, 'flag_' + feature_name, requested_features.get(feature_name, False))
+            setattr(self, 'flag_' + feature_name, requested_features.get(feature_name, False) and __features__[feature_name])
 
         args = ['fuse']
 

--- a/fuse.py
+++ b/fuse.py
@@ -783,8 +783,8 @@ class FUSE(object):
 
     def utimens(self, path, buf):
         if buf:
-            atime = time_of_timespec(buf.contents.actime)
-            mtime = time_of_timespec(buf.contents.modtime)
+            atime = time_of_timespec(buf.contents.actime, self.with_nanosecond_int)
+            mtime = time_of_timespec(buf.contents.modtime, self.with_nanosecond_int)
             times = (atime, mtime)
         else:
             times = None

--- a/fuse.py
+++ b/fuse.py
@@ -376,6 +376,8 @@ class fuse_operations(Structure):
         ('flag_reserved', c_uint, 29),
     ]
 
+# When importing "fuse", you can check this with "hasattr(fuse, 'NANOSECOND_INT_AVAILABLE')"
+NANOSECOND_INT_AVAILABLE = True
 
 def time_of_timespec(ts):
     return int(ts.tv_sec) * 10 ** 9 + int(ts.tv_nsec)

--- a/fuse.py
+++ b/fuse.py
@@ -710,7 +710,7 @@ class FUSE(object):
                 name, attrs, offset = item
                 if attrs:
                     st = c_stat()
-                    set_st_attrs(st, attrs)
+                    set_st_attrs(st, attrs, self.with_nanosecond_int)
                 else:
                     st = None
 
@@ -769,7 +769,7 @@ class FUSE(object):
             fh = fip.contents.fh
 
         attrs = self.operations('getattr', self._decode_optional_path(path), fh)
-        set_st_attrs(st, attrs)
+        set_st_attrs(st, attrs, self.with_nanosecond_int)
         return 0
 
     def lock(self, path, fip, cmd, lock):

--- a/fuse.py
+++ b/fuse.py
@@ -442,6 +442,8 @@ class FUSE(object):
         self.operations = operations
         self.raw_fi = raw_fi
         self.encoding = encoding
+        
+        self.with_nanosecond_int = hasattr(operations, 'WITH_NANOSECOND_INT')
 
         args = ['fuse']
 

--- a/fuse.py
+++ b/fuse.py
@@ -378,7 +378,7 @@ class fuse_operations(Structure):
 
 
 def time_of_timespec(ts):
-    return ts.tv_sec + ts.tv_nsec / 10 ** 9
+    return int(ts.tv_sec) * 10 ** 9 + int(ts.tv_nsec)
 
 def set_st_attrs(st, attrs):
     for key, val in attrs.items():
@@ -387,7 +387,7 @@ def set_st_attrs(st, attrs):
             if timespec is None:
                 continue
             timespec.tv_sec = int(val)
-            timespec.tv_nsec = int((val - timespec.tv_sec) * 10 ** 9)
+            timespec.tv_nsec = int(attrs[key + '_ns'])
         elif hasattr(st, key):
             setattr(st, key, val)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README') as readme:
 
 setup(
     name = 'fusepy',
-    version = '2.0.4',
+    version = '2.0.99',
 
     description = 'Simple ctypes bindings for FUSE',
     long_description = documentation,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README') as readme:
 
 setup(
     name = 'fusepy',
-    version = '2.0.99',
+    version = '2.0.4',
 
     description = 'Simple ctypes bindings for FUSE',
     long_description = documentation,


### PR DESCRIPTION
Synopsis: This pull request supersedes #76, addressing issues and concerns raised in its review and, in addition, adding support for ``UTIME_OMIT`` and ``UTIME_NOW``. 

---

This patch addresses #70 and POSIX compatibility.

Currently, the ``fusepy`` **high level API** (``fuse.py``) handles (and expects) time stamps (atime, mtime, ctime and birthtime) in seconds as floating point numbers, creating quite significant inaccuracies on nanosecond scales. [See this discussion for reference](https://bugs.python.org/issue11457).

This patch allows to switch ``fusepy`` to nanoseconds as integers while keeping full backwards compatibility with older code depending on ``fusepy``'s original behavior. The change affects both values returned by the filesystem (i.e. timestamps from ``getattr``) and values passed into the filesystem (i.e. into ``utimens``).

``fusepy`` now can also handle two types of special values in ``timespec`` structures as defined by POSIX:  ``UTIME_OMIT`` and ``UTIME_NOW`` if requested. This change only affects ``utimens``. Starting with CPython 3.7, the standard library's ``time`` module will offer a new function, ``time_ns``, which will be used by ``fusepy`` if available (in the context of ``UTIME_NOW``).

New code can activate the new features - if available - as follows:

```
from fuse import Operations
try:
	from fuse import __features__ as fuse_features
except ImportError:
	fuse_features = {}

class some_fuse_filesystem(Operations):

	requested_features = {
		'nanosecond_int': True,
		'utime_omit_none': True,
		'utime_now_auto': True
		}

	def __init__(self, *args, **kwargs):
		for flag_name in self.requested_features.keys():
			setattr(
				self,
				'flag_' + flag_name,
				self.requested_features[flag_name] and fuse_features.get(flag_name, False)
				)
```

``fusepy`` will offer an entry in its new ``__features__`` dictionary with a value equal to ``True`` if a feature under the same name is available (or a value equal to ``False`` if a feature is explicitly NOT available). A filesystem has to check its value and fall back to ``False`` if the entry is not present. In return, a filesystem's operations class can be equipped with an attribute (a dictionary) named ``requested_features``, requesting ``fusepy`` to activate certain features. If both dictionaries (``__features__`` and ``requested_features``) contain a certain key (name of feature), in both cases with ``True`` its associated value, a Boolean flag can be set in the filesystem's operations class (in the example it is named ``flag_{feature name}``), switching the filesystem itself to the new behavior.

This pull request has been tested with [pjdfstest](https://github.com/pjd/pjdfstest) through a [development branch of loggedfs-python](https://github.com/pleiszenburg/loggedfs-python/tree/nanosec_optin2).