### PR TITLE
[fusell] Added extra flags for setattr.

### DIFF
--- a/fusell.py
+++ b/fusell.py
@@ -277,7 +277,17 @@ c_bytes_p = ctypes.POINTER(ctypes.c_byte)
 fuse_file_info_p = ctypes.POINTER(fuse_file_info)
 fuse_forget_data_p = ctypes.POINTER(fuse_forget_data)
 
-FUSE_SET_ATTR = ('st_mode', 'st_uid', 'st_gid', 'st_size', 'st_atime', 'st_mtime')
+FUSE_SET_ATTR = (
+    'st_mode',
+    'st_uid',
+    'st_gid',
+    'st_size',
+    'st_atime',
+    'st_mtime',
+    None,  # Flag 1<<6 (FATTR_FH) is never received by setattr
+    'st_atime_now',
+    'st_mtime_now',
+    'st_ctime')
 
 class fuse_entry_param(ctypes.Structure):
     _fields_ = [


### PR DESCRIPTION
All flags are defined here: https://github.com/libfuse/libfuse/blob/8157b4d9b9f13449f4750f1ef40f9f20a2242eec/include/fuse_lowlevel.h#L134

- `st_atime_now` and `st_mtime_now` might require special attention?
- The flag 1<<6 (FATTR_FH) is invalid for setattr