### PR TITLE
Add `nonseekable` and `flock_release` to fuse_file_info

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -325,7 +325,9 @@ class fuse_file_info(ctypes.Structure):
         ('direct_io', ctypes.c_uint, 1),
         ('keep_cache', ctypes.c_uint, 1),
         ('flush', ctypes.c_uint, 1),
-        ('padding', ctypes.c_uint, 29),
+        ('nonseekable', ctypes.c_uint, 1),
+        ('flock_release', ctypes.c_uint, 1),
+        ('padding', ctypes.c_uint, 27),
         ('fh', ctypes.c_uint64),
         ('lock_owner', ctypes.c_uint64)]
 

--- a/fusell.py
+++ b/fusell.py
@@ -247,7 +247,9 @@ class fuse_file_info(ctypes.Structure):
         ('direct_io', ctypes.c_uint, 1),
         ('keep_cache', ctypes.c_uint, 1),
         ('flush', ctypes.c_uint, 1),
-        ('padding', ctypes.c_uint, 29),
+        ('nonseekable', ctypes.c_uint, 1),
+        ('flock_release', ctypes.c_uint, 1),
+        ('padding', ctypes.c_uint, 27),
         ('fh', ctypes.c_uint64),
         ('lock_owner', ctypes.c_uint64)]
 


### PR DESCRIPTION
These flags were missing from the struct definitions.

As discussed on #83. This PR superceeds #84 (Which was made agains my master branch and got mixed up with other changes :man_facepalming: )
