### PR TITLE
[fuse3] [fusell] Add missing `flags` argument to `rename` callback

### DIFF
--- a/fusell.py
+++ b/fusell.py
@@ -312,7 +312,7 @@ class fuse_lowlevel_ops(ctypes.Structure):
 
         ('rename', ctypes.CFUNCTYPE(
             None, fuse_req_t, fuse_ino_t, ctypes.c_char_p, fuse_ino_t,
-            ctypes.c_char_p)),
+            ctypes.c_char_p, ctypes.c_uint)),
 
         ('link', ctypes.CFUNCTYPE(
             None, fuse_req_t, fuse_ino_t, fuse_ino_t, ctypes.c_char_p)),
@@ -502,6 +502,9 @@ class FUSELL(object):
         to_set_list = setattr_mask_to_list(to_set)
         fi_dict = struct_to_dict(fi)
         self.setattr(req, ino, attr_dict, to_set_list, fi_dict)
+
+    def fuse_rename(self, req, parent, name, newparent, newname, flags):
+        self.rename(req, parent, name, newparent, newname)
 
     def fuse_open(self, req, ino, fi):
         self.open(req, ino, struct_to_dict(fi))


### PR DESCRIPTION
> *flags* may be `RENAME_EXCHANGE` or `RENAME_NOREPLACE`. If
> RENAME_NOREPLACE is specified, the filesystem must not
> overwrite *newname* if it exists and return an error
> instead. If `RENAME_EXCHANGE` is specified, the filesystem
> must atomically exchange the two files, i.e. both must
> exist and neither may be deleted.

I also added an intermediary `fuse_rename` function that drops the extra argument for backwards compatibility
