### PR TITLE
Pass flags to create in non raw_fi mode.

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -1001,7 +1001,7 @@ class FUSE(object):
         if self.raw_fi:
             return self.operations('create', path, mode, fi)
         else:
-            fi.fh = self.operations('create', path, mode)
+            fi.fh = self.operations('create', path, mode, fi.flags)
             return 0
 
     def ftruncate(self, path, length, fip):
@@ -1088,8 +1088,9 @@ class Operations(object):
 
     def create(self, path, mode, fi=None):
         '''
-        When raw_fi is False (default case), fi is None and create should
-        return a numerical file handle.
+        When raw_fi is False (default case) create should return a
+        numerical file handle and the signature of create becomes:
+          create(self, path, mode, flags)
 
         When raw_fi is True the file handle should be set directly by create
         and return 0.


### PR DESCRIPTION
Calls to open with O_CREAT on a file system will end up with a call to
create on fuse. So it is possible to "create" with O_RDWR.  Users need
to make the distinction between O_RDWR and O_WRONLY.

It is common to open with O_CREAT|O_RDWR before mmap'ing the new file.
If the filesystem does not allow reading of that file, it will cause a
bus error.