### PR TITLE
fixing TypeError: an integer is required when val is None

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -586,7 +586,7 @@ def set_st_attrs(st, attrs, use_ns=False):
             else:
                 timespec.tv_sec = int(val)
                 timespec.tv_nsec = int((val - timespec.tv_sec) * 1E9)
-        elif hasattr(st, key):
+        elif hasattr(st, key) and val is not None:
             setattr(st, key, val)
 
 


### PR DESCRIPTION
Error happens, when specific keys don't have value.

Complete error output:

`ERROR:fuse:Uncaught exception from FUSE operation getattr, returning errno.EINVAL.
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/fuse.py", line 735, in _wrapper
    return func(*args, **kwargs) or 0
  File "/usr/lib/python2.7/site-packages/fuse.py", line 775, in getattr
    return self.fgetattr(path, buf, None)
  File "/usr/lib/python2.7/site-packages/fuse.py", line 1029, in fgetattr
    set_st_attrs(st, attrs, use_ns=self.use_ns)
  File "/usr/lib/python2.7/site-packages/fuse.py", line 591, in set_st_attrs
    setattr(st, key, val)
TypeError: an integer is required`