### PR TITLE
ensure "fusell" package is added to egg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     maintainer = 'Terence Honles',
     maintainer_email = 'terence@honles.com',
     license = 'ISC',
-    py_modules=['fuse'],
+    py_modules=['fuse','fusell'],
     url = 'http://github.com/fusepy/fusepy',
 
     classifiers = [


### PR DESCRIPTION
`pip install fusepy` doesn't install the `fusell` package, as this was left out of `setup.py`.

I presume this was unintentional?  If not, will you be packaging/publishing this separately?