### PR TITLE
FUSE::_wrapper() is a static method, so it shouldn't refer to 'self' 

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -753,7 +753,7 @@ class FUSE(object):
                     return -errno.EINVAL
 
         except BaseException as e:
-            self.__critical_exception = e
+            ## self.__critical_exception = e
             log.critical(
                 "Uncaught critical exception from FUSE operation %s, aborting.",
                 func.__name__, exc_info=True)


### PR DESCRIPTION
As it says: we shall either make `_wrapper()` a normal method, or disable that line that refers to `self`.