### PR TITLE
Add FUSE 3 support

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -28,7 +28,6 @@ from ctypes import (
     POINTER,
     c_char_p,
     c_byte,
-    c_voidp,
     c_size_t,
     c_ssize_t,
     c_int,
@@ -465,11 +464,11 @@ class fuse_file_info(ctypes.Structure):
 
 class fuse_context(ctypes.Structure):
     _fields_ = [
-        ('fuse', ctypes.c_voidp),
+        ('fuse', ctypes.c_void_p),
         ('uid', c_uid_t),
         ('gid', c_gid_t),
         ('pid', c_pid_t),
-        ('private_data', ctypes.c_voidp),
+        ('private_data', ctypes.c_void_p),
         # Added in 2.8. Note that this is an ABI break because programs compiled against 2.7
         # will allocate a smaller struct leading to out-of-bound accesses when used for a 2.8
         # shared library! It shouldn't hurt the other way around to have a larger struct than
@@ -484,7 +483,7 @@ class fuse_operations(ctypes.Structure):
     _fields_ = [
         ('getattr', CFUNCTYPE(c_int, c_char_p, POINTER(c_stat))),
         ('readlink', CFUNCTYPE(c_int, c_char_p, POINTER(c_byte), c_size_t)),
-        ('getdir', c_voidp),    # Deprecated, use readdir
+        ('getdir', c_void_p),    # Deprecated, use readdir
         ('mknod', CFUNCTYPE(c_int, c_char_p, c_mode_t, c_dev_t)),
         ('mkdir', CFUNCTYPE(c_int, c_char_p, c_mode_t)),
         ('unlink', CFUNCTYPE(c_int, c_char_p)),
@@ -495,7 +494,7 @@ class fuse_operations(ctypes.Structure):
         ('chmod', CFUNCTYPE(c_int, c_char_p, c_mode_t)),
         ('chown', CFUNCTYPE(c_int, c_char_p, c_uid_t, c_gid_t)),
         ('truncate', CFUNCTYPE(c_int, c_char_p, c_off_t)),
-        ('utime', c_voidp),     # Deprecated, use utimens
+        ('utime', c_void_p),     # Deprecated, use utimens
         ('open', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
         ('read', CFUNCTYPE(
             c_int, c_char_p, POINTER(c_byte),
@@ -515,19 +514,19 @@ class fuse_operations(ctypes.Structure):
         ('readdir', CFUNCTYPE(
             c_int,
             c_char_p,
-            c_voidp,
-            CFUNCTYPE(c_int, c_voidp, c_char_p, POINTER(c_stat), c_off_t),
+            c_void_p,
+            CFUNCTYPE(c_int, c_void_p, c_char_p, POINTER(c_stat), c_off_t),
             c_off_t,
             POINTER(fuse_file_info))),
         ('releasedir', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
         ('fsyncdir', CFUNCTYPE(c_int, c_char_p, c_int, POINTER(fuse_file_info))),
-        ('init', CFUNCTYPE(c_voidp, c_voidp)),
-        ('destroy', CFUNCTYPE(c_voidp, c_voidp)),
+        ('init', CFUNCTYPE(c_void_p, c_void_p)),
+        ('destroy', CFUNCTYPE(c_void_p, c_void_p)),
         ('access', CFUNCTYPE(c_int, c_char_p, c_int)),
         ('create', CFUNCTYPE(c_int, c_char_p, c_mode_t, POINTER(fuse_file_info))),
         ('ftruncate', CFUNCTYPE(c_int, c_char_p, c_off_t, POINTER(fuse_file_info))),
         ('fgetattr', CFUNCTYPE(c_int, c_char_p, POINTER(c_stat), POINTER(fuse_file_info))),
-        ('lock', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info), c_int, c_voidp)),
+        ('lock', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info), c_int, c_void_p)),
         ('utimens', CFUNCTYPE(c_int, c_char_p, POINTER(c_utimbuf))),
         ('bmap', CFUNCTYPE(c_int, c_char_p, c_size_t, POINTER(c_uint64))),
 

--- a/fuse.py
+++ b/fuse.py
@@ -103,7 +103,7 @@ if not _libfuse_path:
         _libiconv = ctypes.CDLL(find_library('iconv'), ctypes.RTLD_GLOBAL)
 
         _libfuse_path = (find_library('fuse4x') or find_library('osxfuse') or
-                         find_library('fuse'))
+                         find_library('fuse') or find_library('fuse-t'))
     elif _system == 'Windows':
         try:
             import _winreg as reg

--- a/fuse.py
+++ b/fuse.py
@@ -591,7 +591,7 @@ class fuse_operations(ctypes.Structure):
 
         ('bmap', ctypes.CFUNCTYPE(
             ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t,
-            ctypes.POINTER(ctypes.c_ulonglong))),
+            ctypes.POINTER(ctypes.c_uint64))),
 
         ('flag_nullpath_ok', ctypes.c_uint, 1),
         ('flag_nopath', ctypes.c_uint, 1),

--- a/fuse.py
+++ b/fuse.py
@@ -436,32 +436,19 @@ else:
             ('f_flag', ctypes.c_ulong),
             ('f_namemax', ctypes.c_ulong)]
 
-if _system == 'Windows' or _system.startswith('CYGWIN'):
-    class fuse_file_info(ctypes.Structure):
-        _fields_ = [
-            ('flags', ctypes.c_int),
-            ('fh_old', ctypes.c_int),
-            ('writepage', ctypes.c_int),
-            ('direct_io', ctypes.c_uint, 1),
-            ('keep_cache', ctypes.c_uint, 1),
-            ('flush', ctypes.c_uint, 1),
-            ('padding', ctypes.c_uint, 29),
-            ('fh', ctypes.c_uint64),
-            ('lock_owner', ctypes.c_uint64)]
-else:
-    class fuse_file_info(ctypes.Structure):
-        _fields_ = [
-            ('flags', ctypes.c_int),
-            ('fh_old', ctypes.c_ulong),
-            ('writepage', ctypes.c_int),
-            ('direct_io', ctypes.c_uint, 1),
-            ('keep_cache', ctypes.c_uint, 1),
-            ('flush', ctypes.c_uint, 1),
-            ('nonseekable', ctypes.c_uint, 1),
-            ('flock_release', ctypes.c_uint, 1),
-            ('padding', ctypes.c_uint, 27),
-            ('fh', ctypes.c_uint64),
-            ('lock_owner', ctypes.c_uint64)]
+class fuse_file_info(ctypes.Structure):
+    _fields_ = [
+        ('flags', ctypes.c_int),
+        ('fh_old', ctypes.c_ulong),
+        ('writepage', ctypes.c_int),
+        ('direct_io', ctypes.c_uint, 1),      # Introduced in libfuse 2.4
+        ('keep_cache', ctypes.c_uint, 1),     # Introduced in libfuse 2.4
+        ('flush', ctypes.c_uint, 1),          # Introduced in libfuse 2.6
+        ('nonseekable', ctypes.c_uint, 1),    # Introduced in libfuse 2.8
+        ('flock_release', ctypes.c_uint, 1),  # Introduced in libfuse 2.9
+        ('padding', ctypes.c_uint, 27),
+        ('fh', ctypes.c_uint64),
+        ('lock_owner', ctypes.c_uint64)]
 
 class fuse_context(ctypes.Structure):
     _fields_ = [

--- a/fuse.py
+++ b/fuse.py
@@ -721,8 +721,7 @@ class FUSE(object):
             else:
                 yield '%s=%s' % (key, value)
 
-    @staticmethod
-    def _wrapper(func, *args, **kwargs):
+    def _wrapper(self, func, *args, **kwargs):
         'Decorator for the methods that follow'
 
         try:

--- a/fuse.py
+++ b/fuse.py
@@ -609,7 +609,7 @@ def set_st_attrs(st, attrs, use_ns=False):
             else:
                 timespec.tv_sec = int(val)
                 timespec.tv_nsec = int((val - timespec.tv_sec) * 1E9)
-        elif hasattr(st, key):
+        elif getattr(st, key, None) is not None:
             setattr(st, key, val)
 
 

--- a/fuse.py
+++ b/fuse.py
@@ -456,7 +456,13 @@ class fuse_context(ctypes.Structure):
         ('uid', c_uid_t),
         ('gid', c_gid_t),
         ('pid', c_pid_t),
-        ('private_data', ctypes.c_voidp)]
+        ('private_data', ctypes.c_voidp),
+        # Added in 2.8. Note that this is an ABI break because programs compiled against 2.7
+        # will allocate a smaller struct leading to out-of-bound accesses when used for a 2.8
+        # shared library! It shouldn't hurt the other way around to have a larger struct than
+        # the shared library expects. The newer members will simply be ignored.
+        ('umask', c_mode_t),
+    ]
 
 _libfuse.fuse_get_context.restype = ctypes.POINTER(fuse_context)
 

--- a/fuse.py
+++ b/fuse.py
@@ -23,6 +23,19 @@ import logging
 import os
 import warnings
 
+from ctypes import (
+    CFUNCTYPE,
+    POINTER,
+    c_char_p,
+    c_byte,
+    c_voidp,
+    c_size_t,
+    c_ssize_t,
+    c_int,
+    c_uint,
+    c_uint64,
+    c_void_p,
+)
 from ctypes.util import find_library
 from platform import machine, system
 from signal import signal, SIGINT, SIG_DFL
@@ -469,131 +482,64 @@ _libfuse.fuse_get_context.restype = ctypes.POINTER(fuse_context)
 
 class fuse_operations(ctypes.Structure):
     _fields_ = [
-        ('getattr', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(c_stat))),
-
-        ('readlink', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(ctypes.c_byte),
-            ctypes.c_size_t)),
-
-        ('getdir', ctypes.c_voidp),    # Deprecated, use readdir
-
-        ('mknod', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, c_mode_t, c_dev_t)),
-
-        ('mkdir', ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p, c_mode_t)),
-        ('unlink', ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p)),
-        ('rmdir', ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p)),
-
-        ('symlink', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p)),
-
-        ('rename', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p)),
-
-        ('link', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p)),
-
-        ('chmod', ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p, c_mode_t)),
-
-        ('chown', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, c_uid_t, c_gid_t)),
-
-        ('truncate', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, c_off_t)),
-
-        ('utime', ctypes.c_voidp),     # Deprecated, use utimens
-        ('open', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info))),
-
-        ('read', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(ctypes.c_byte),
-            ctypes.c_size_t, c_off_t, ctypes.POINTER(fuse_file_info))),
-
-        ('write', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(ctypes.c_byte),
-            ctypes.c_size_t, c_off_t, ctypes.POINTER(fuse_file_info))),
-
-        ('statfs', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(c_statvfs))),
-
-        ('flush', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info))),
-
-        ('release', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info))),
-
-        ('fsync', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_int,
-            ctypes.POINTER(fuse_file_info))),
-
+        ('getattr', CFUNCTYPE(c_int, c_char_p, POINTER(c_stat))),
+        ('readlink', CFUNCTYPE(c_int, c_char_p, POINTER(c_byte), c_size_t)),
+        ('getdir', c_voidp),    # Deprecated, use readdir
+        ('mknod', CFUNCTYPE(c_int, c_char_p, c_mode_t, c_dev_t)),
+        ('mkdir', CFUNCTYPE(c_int, c_char_p, c_mode_t)),
+        ('unlink', CFUNCTYPE(c_int, c_char_p)),
+        ('rmdir', CFUNCTYPE(c_int, c_char_p)),
+        ('symlink', CFUNCTYPE(c_int, c_char_p, c_char_p)),
+        ('rename', CFUNCTYPE(c_int, c_char_p, c_char_p)),
+        ('link', CFUNCTYPE(c_int, c_char_p, c_char_p)),
+        ('chmod', CFUNCTYPE(c_int, c_char_p, c_mode_t)),
+        ('chown', CFUNCTYPE(c_int, c_char_p, c_uid_t, c_gid_t)),
+        ('truncate', CFUNCTYPE(c_int, c_char_p, c_off_t)),
+        ('utime', c_voidp),     # Deprecated, use utimens
+        ('open', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
+        ('read', CFUNCTYPE(
+            c_int, c_char_p, POINTER(c_byte),
+            c_size_t, c_off_t, POINTER(fuse_file_info))),
+        ('write', CFUNCTYPE(
+            c_int, c_char_p, POINTER(c_byte),
+            c_size_t, c_off_t, POINTER(fuse_file_info))),
+        ('statfs', CFUNCTYPE(c_int, c_char_p, POINTER(c_statvfs))),
+        ('flush', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
+        ('release', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
+        ('fsync', CFUNCTYPE(c_int, c_char_p, c_int, POINTER(fuse_file_info))),
         ('setxattr', setxattr_t),
         ('getxattr', getxattr_t),
-
-        ('listxattr', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(ctypes.c_byte),
-            ctypes.c_size_t)),
-
-        ('removexattr', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p)),
-
-        ('opendir', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info))),
-
-        ('readdir', ctypes.CFUNCTYPE(
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_voidp,
-            ctypes.CFUNCTYPE(
-                ctypes.c_int, ctypes.c_voidp, ctypes.c_char_p,
-                ctypes.POINTER(c_stat), c_off_t),
+        ('listxattr', CFUNCTYPE(c_int, c_char_p, POINTER(c_byte), c_size_t)),
+        ('removexattr', CFUNCTYPE(c_int, c_char_p, c_char_p)),
+        ('opendir', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
+        ('readdir', CFUNCTYPE(
+            c_int,
+            c_char_p,
+            c_voidp,
+            CFUNCTYPE(c_int, c_voidp, c_char_p, POINTER(c_stat), c_off_t),
             c_off_t,
-            ctypes.POINTER(fuse_file_info))),
+            POINTER(fuse_file_info))),
+        ('releasedir', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info))),
+        ('fsyncdir', CFUNCTYPE(c_int, c_char_p, c_int, POINTER(fuse_file_info))),
+        ('init', CFUNCTYPE(c_voidp, c_voidp)),
+        ('destroy', CFUNCTYPE(c_voidp, c_voidp)),
+        ('access', CFUNCTYPE(c_int, c_char_p, c_int)),
+        ('create', CFUNCTYPE(c_int, c_char_p, c_mode_t, POINTER(fuse_file_info))),
+        ('ftruncate', CFUNCTYPE(c_int, c_char_p, c_off_t, POINTER(fuse_file_info))),
+        ('fgetattr', CFUNCTYPE(c_int, c_char_p, POINTER(c_stat), POINTER(fuse_file_info))),
+        ('lock', CFUNCTYPE(c_int, c_char_p, POINTER(fuse_file_info), c_int, c_voidp)),
+        ('utimens', CFUNCTYPE(c_int, c_char_p, POINTER(c_utimbuf))),
+        ('bmap', CFUNCTYPE(c_int, c_char_p, c_size_t, POINTER(c_uint64))),
 
-        ('releasedir', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info))),
+        ('flag_nullpath_ok', c_uint, 1),
+        ('flag_nopath', c_uint, 1),
+        ('flag_utime_omit_ok', c_uint, 1),
+        ('flag_reserved', c_uint, 29),
 
-        ('fsyncdir', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_int,
-            ctypes.POINTER(fuse_file_info))),
-
-        ('init', ctypes.CFUNCTYPE(ctypes.c_voidp, ctypes.c_voidp)),
-        ('destroy', ctypes.CFUNCTYPE(ctypes.c_voidp, ctypes.c_voidp)),
-
-        ('access', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_int)),
-
-        ('create', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, c_mode_t,
-            ctypes.POINTER(fuse_file_info))),
-
-        ('ftruncate', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, c_off_t,
-            ctypes.POINTER(fuse_file_info))),
-
-        ('fgetattr', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(c_stat),
-            ctypes.POINTER(fuse_file_info))),
-
-        ('lock', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info),
-            ctypes.c_int, ctypes.c_voidp)),
-
-        ('utimens', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(c_utimbuf))),
-
-        ('bmap', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t,
-            ctypes.POINTER(ctypes.c_uint64))),
-
-        ('flag_nullpath_ok', ctypes.c_uint, 1),
-        ('flag_nopath', ctypes.c_uint, 1),
-        ('flag_utime_omit_ok', ctypes.c_uint, 1),
-        ('flag_reserved', ctypes.c_uint, 29),
-
-        ('ioctl', ctypes.CFUNCTYPE(
-            ctypes.c_int, ctypes.c_char_p, ctypes.c_uint, ctypes.c_void_p,
-            ctypes.POINTER(fuse_file_info), ctypes.c_uint, ctypes.c_void_p)),
+        ('ioctl', CFUNCTYPE(
+            c_int, c_char_p, c_uint, c_void_p,
+            POINTER(fuse_file_info), c_uint, c_void_p),
+        ),
     ]
 
 

--- a/fuse.py
+++ b/fuse.py
@@ -54,7 +54,7 @@ log = logging.getLogger("fuse")
 _system = system()
 _machine = machine()
 
-if _system == 'Windows':
+if _system == 'Windows' or _system.startswith('CYGWIN'):
     # NOTE:
     #
     # sizeof(long)==4 on Windows 32-bit and 64-bit

--- a/fuse.py
+++ b/fuse.py
@@ -13,6 +13,8 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+# mypy: ignore-errors
+
 from __future__ import print_function, absolute_import, division
 
 import ctypes

--- a/fuse.py
+++ b/fuse.py
@@ -736,7 +736,7 @@ class FUSE(object):
                     return func(*args, **kwargs) or 0
 
                 except OSError as e:
-                    if e.errno > 0:
+                    if isinstance(e.errno, int) and e.errno > 0:
                         log.debug(
                             "FUSE operation %s raised a %s, returning errno %s.",
                             func.__name__, type(e), e.errno, exc_info=True)

--- a/fuse.py
+++ b/fuse.py
@@ -1093,7 +1093,7 @@ class FUSE(object):
         if self.raw_fi:
             return self.operations('create', path, mode, fi)
         else:
-            fi.fh = self.operations('create', path, mode)
+            fi.fh = self.operations('create', path, mode, fi.flags)
             return 0
 
     def ftruncate(self, path, length, fip):
@@ -1209,8 +1209,9 @@ class Operations(object):
     @_nullable_dummy_function
     def create(self, path, mode, fi=None):
         '''
-        When raw_fi is False (default case), fi is None and create should
-        return a numerical file handle.
+        When raw_fi is False (default case), create should return a
+        numerical file handle and the signature of create becomes:
+          create(self, path, mode, flags)
 
         When raw_fi is True the file handle should be set directly by create
         and return 0.


### PR DESCRIPTION
I am aware that this project [has not](https://github.com/fusepy/fusepy/issues/134) seen [updates](https://github.com/pleiszenburg/refuse/issues/1) for years. This PR can be seen as information for other fusepy users who need FUSE 3 support.

This PR adds many fixes that have already been done multiple times on multiple forks and adds FUSE 3 support. The FUSE 3 support is mostly transparent, i.e., it will simply work with a FUSE 3 shared library file when it can be found without the fusepy user needing to change everything. I only did this for the high-level API in fuse.py. For now it prioritizes simply interoperability with FUSE 3. In the future, support for newly added functions and function arguments may be added, especially when they can lead to performance gains.

It will not work with anything newer than libfuse 3.16 because libfuse has a really surprising track record of breaking [ABI compatibility](https://github.com/libfuse/libfuse/issues/1029). This PR tries to work around this by checking for the minor version and conditionally adding struct members and changing struct member orders and such for affected minor versions.

It also keeps the monolithic design, which is very nice for simply copying the fuse.py file into my dependent project [ratarmount](https://github.com/mxmlnkn/ratarmount/issues/101).