### PR TITLE
Bugfix for invalid reference in fuse_operations.lock

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -548,7 +548,7 @@ class fuse_operations(ctypes.Structure):
 
         ('lock', ctypes.CFUNCTYPE(
             ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(fuse_file_info),
-            ctypes.c_int, ctypes.c_voidp)),
+            ctypes.c_int, ctypes.c_void_p)),
 
         ('utimens', ctypes.CFUNCTYPE(
             ctypes.c_int, ctypes.c_char_p, ctypes.POINTER(c_utimbuf))),


### PR DESCRIPTION
fixed invalid reference to ctypes.c_void_p within definition for fuse_operations.lock